### PR TITLE
use find to get a list of everything in /app/.dokku and copy in a for loop

### DIFF
--- a/pre-build
+++ b/pre-build
@@ -3,6 +3,7 @@ set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$1";
 APP_PATH="$DOKKU_ROOT/$APP"
+IMAGE="dokku/$APP"
 echo "-----> Copying any files from app's .dokku/* to ${APP_PATH}..."
 
 CID=$(docker run -d $IMAGE /bin/sh)

--- a/pre-build
+++ b/pre-build
@@ -5,6 +5,9 @@ APP="$1"; IMAGE="dokku/$APP"
 APP_PATH="$DOKKU_ROOT/$APP"
 echo "-----> Copying any files from app's .dokku/* to ${APP_PATH}..."
 
+CONFIG_FILES=$(docker run -i -a stdout $IMAGE /bin/bash -c "find /app/.dokku/ -type f")
 CID=$(docker run -d $IMAGE /bin/sh)
-docker cp $CID:/app/.dokku/* $APP_PATH 2> /dev/null || true
+for file in $CONFIG_FILES; do
+	docker cp $CID:$file $APP_PATH || true
+done
 docker rm -f $CID

--- a/pre-build
+++ b/pre-build
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
-APP="$1";
+APP="$1"; IMAGE="dokku/$APP"
 APP_PATH="$DOKKU_ROOT/$APP"
-IMAGE="dokku/$APP"
 echo "-----> Copying any files from app's .dokku/* to ${APP_PATH}..."
 
 CID=$(docker run -d $IMAGE /bin/sh)


### PR DESCRIPTION
closes #3 

Since `docker cp $CID:/app/.dokku/*` does not work (at least in docker 1.1.2), this will find all files in /app/.dokku and copy them in a for loop. I'm open to suggestions on a more elegant method but this works for now.
